### PR TITLE
Fix typo in HTML meta description

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
 	<head>
 		<title>10 Usability Heuristics for User Interface Design — Read&Study</title>
-		<meta name="description" content="Read and study Jacob Nielsen`s famous 10 Usabulity Heuristics">
+		<meta name="description" content="Read and study Jacob Nielsen`s famous 10 Usability Heuristics">
 
 		<meta name='yandex-verification' content='4a3dd848c54810df' />
 


### PR DESCRIPTION
## Summary
- correct typo "Usabulity" to "Usability" in meta description

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846fa5de5e88331a2e552dfb48f15c9