### PR TITLE
Fix incorrect class name

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 						</div>
 
 						<h3 class="definition js-description-switcher"><span class="numeral js-numeral">01</span> Visibility of system status</h3>
-						<p class="description js-desctiption-body">The system should always keep users informed about what is going on, through appropriate feedback within reasonable time.</p>
+						<p class="description js-description-body">The system should always keep users informed about what is going on, through appropriate feedback within reasonable time.</p>
 					</div>
 					<button class="gotit js-btn-cover-switcher hidden">Got it!</button>
 				</section>
@@ -58,7 +58,7 @@
 							<h2>2</h2>
 						</div>
 						<h3 class="definition js-description-switcher"><span class="numeral js-numeral">02</span> Match between system and the real world</h3>
-						<p class="description js-desctiption-body">The system should speak the users' language, with words, phrases and concepts familiar to&nbsp;the user, rather than system-oriented terms. Follow real-world conventions, making information appear in a&nbsp;natural and logical order.</p>
+						<p class="description js-description-body">The system should speak the users' language, with words, phrases and concepts familiar to&nbsp;the user, rather than system-oriented terms. Follow real-world conventions, making information appear in a&nbsp;natural and logical order.</p>
 					</div>
 					<button class="gotit js-btn-cover-switcher hidden">Got it!</button>
 				</section>
@@ -68,7 +68,7 @@
 							<h2>3</h2>
 						</div>
 						<h3 class="definition js-description-switcher"><span class="numeral js-numeral">03</span> User control and freedom</h3>
-						<p class="description js-desctiption-body">Users often choose system functions by mistake and will need a clearly marked <em>emergency exit</em> to leave the unwanted state without having to go through an extended dialogue. Support undo and redo.</p>
+						<p class="description js-description-body">Users often choose system functions by mistake and will need a clearly marked <em>emergency exit</em> to leave the unwanted state without having to go through an extended dialogue. Support undo and redo.</p>
 					</div>
 					<button class="gotit js-btn-cover-switcher hidden">Got it!</button>
 				</section>
@@ -78,7 +78,7 @@
 							<h2>4</h2>
 						</div>
 						<h3 class="definition js-description-switcher"><span class="numeral js-numeral">04</span> Consistency and standards</h3>
-						<p class="description js-desctiption-body">Users should not have to&nbsp;wonder whether different words, situations, or actions mean the same thing. Follow platform conventions.</p>
+						<p class="description js-description-body">Users should not have to&nbsp;wonder whether different words, situations, or actions mean the same thing. Follow platform conventions.</p>
 					</div>
 					<button class="gotit js-btn-cover-switcher hidden">Got it!</button>
 				</section>
@@ -88,7 +88,7 @@
 							<h2>5</h2>
 						</div>
 						<h3 class="definition js-description-switcher"><span class="numeral js-numeral">05</span> Error prevention</h3>
-						<p class="description js-desctiption-body">Even better than good error messages is a&nbsp;careful design which prevents a&nbsp;problem from occurring in the first place. Either eliminate error-prone conditions or check for them and present users with a&nbsp;confirmation option before they commit to the action.</p>
+						<p class="description js-description-body">Even better than good error messages is a&nbsp;careful design which prevents a&nbsp;problem from occurring in the first place. Either eliminate error-prone conditions or check for them and present users with a&nbsp;confirmation option before they commit to the action.</p>
 					</div>
 					<button class="gotit js-btn-cover-switcher hidden">Got it!</button>
 				</section>
@@ -98,7 +98,7 @@
 							<h2>6</h2>
 						</div>
 						<h3 class="definition js-description-switcher"><span class="numeral js-numeral">06</span> Recognition rather than recall</h3>
-						<p class="description js-desctiption-body">Minimize the user's memory load by&nbsp;making objects, actions, and options visible. The user should not have to&nbsp;remember information from one part of the dialogue to&nbsp;another. Instructions for use of the system should be visible or easily retrievable whenever appropriate.</p>
+						<p class="description js-description-body">Minimize the user's memory load by&nbsp;making objects, actions, and options visible. The user should not have to&nbsp;remember information from one part of the dialogue to&nbsp;another. Instructions for use of the system should be visible or easily retrievable whenever appropriate.</p>
 					</div>
 					<button class="gotit js-btn-cover-switcher hidden">Got it!</button>
 				</section>
@@ -108,7 +108,7 @@
 							<h2>7</h2>
 						</div>
 						<h3 class="definition js-description-switcher"><span class="numeral js-numeral">07</span> Flexibility and efficiency of use</h3>
-						<p class="description js-desctiption-body">Accelerators — unseen by the novice user — may often speed up the interaction for the expert user such that the system can cater to both inexperienced and experienced users. Allow users to&nbsp;tailor frequent actions.</p>
+						<p class="description js-description-body">Accelerators — unseen by the novice user — may often speed up the interaction for the expert user such that the system can cater to both inexperienced and experienced users. Allow users to&nbsp;tailor frequent actions.</p>
 					</div>
 					<button class="gotit js-btn-cover-switcher hidden">Got it!</button>
 				</section>
@@ -118,7 +118,7 @@
 							<h2>8</h2>
 						</div>
 						<h3 class="definition js-description-switcher"><span class="numeral js-numeral">08</span> Aesthetic and minimalist design</h3>
-						<p class="description js-desctiption-body">Dialogues should not contain information which is irrelevant or&nbsp;rarely needed. Every extra unit of information in a&nbsp;dialogue competes with the relevant units of&nbsp;information and diminishes their relative visibility.</p>
+						<p class="description js-description-body">Dialogues should not contain information which is irrelevant or&nbsp;rarely needed. Every extra unit of information in a&nbsp;dialogue competes with the relevant units of&nbsp;information and diminishes their relative visibility.</p>
 					</div>
 					<button class="gotit js-btn-cover-switcher hidden">Got it!</button>
 				</section>
@@ -128,7 +128,7 @@
 							<h2>9</h2>
 						</div>
 						<h3 class="definition js-description-switcher"><span class="numeral js-numeral">09</span>  Help users recognize, diagnose, and recover from errors</h3>
-						<p class="description js-desctiption-body">Error messages should be expressed in&nbsp;plain language (no codes), precisely indicate the problem, and constructively suggest a&nbsp;solution.</p>
+						<p class="description js-description-body">Error messages should be expressed in&nbsp;plain language (no codes), precisely indicate the problem, and constructively suggest a&nbsp;solution.</p>
 					</div>
 					<button class="gotit js-btn-cover-switcher hidden">Got it!</button>
 				</section>
@@ -138,7 +138,7 @@
 							<h2>10</h2>
 						</div>
 						<h3 class="definition js-description-switcher"><span class="numeral js-numeral">10</span> Help and documentation</h3>
-						<p class="description js-desctiption-body">Even though it is better if the system can be used without documentation, it may be necessary to&nbsp;provide help and documentation. Any such information should be easy to&nbsp;search, focused on the user's task, list concrete steps to be&nbsp;carried out, and not be&nbsp;too large.</p>
+						<p class="description js-description-body">Even though it is better if the system can be used without documentation, it may be necessary to&nbsp;provide help and documentation. Any such information should be easy to&nbsp;search, focused on the user's task, list concrete steps to be&nbsp;carried out, and not be&nbsp;too large.</p>
 					</div>
 					<button class="gotit js-btn-cover-switcher hidden">Got it!</button>
 				</section>

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -12,7 +12,7 @@ $(function () {
 	   mySwitchersActive = false;
 	   $('.js-cover-interactive').removeClass('visible');
 	   $('.js-description-switcher').removeClass('interactive');
-	   $('.js-desctiption-body').removeClass('hidden');
+	   $('.js-description-body').removeClass('hidden');
 	   $('.js-btn-cover-switcher').addClass('hidden');
 	   $('.js-numeral').toggle();
 	});
@@ -23,7 +23,7 @@ $(function () {
 	  		var $this = $(this);
 	  		$this.removeClass('visible');
 	  		$this.parents('.js-parent-section').find('.js-description-switcher').addClass('interactive');
-			$this.parents('.js-parent-section').find('.js-desctiption-body').addClass('hidden');
+			$this.parents('.js-parent-section').find('.js-description-body').addClass('hidden');
 	  		$this.parents('.js-parent-section').find('.js-btn-cover-switcher').removeClass('hidden');
 		}
 	});
@@ -31,7 +31,7 @@ $(function () {
 	$('.js-description-switcher').on('click', function() {
 		if (mySwitchersActive) {
 	  		var $this = $(this);
-			$this.parents('.js-parent-section').find('.js-desctiption-body').toggleClass('hidden');
+			$this.parents('.js-parent-section').find('.js-description-body').toggleClass('hidden');
 		}
 	});
 


### PR DESCRIPTION
## Summary
- fix typos in index.html class names
- fix js selectors for the renamed class

## Testing
- `node -e "const fs=require('fs');const html=fs.readFileSync('index.html','utf8');console.log((html.match(/js-description-body/g)||[]).length);"`
- `grep -R "js-desctiption-body" -n || true`

------
https://chatgpt.com/codex/tasks/task_e_6846fa98e47c8331823b00c7fd24a8f3